### PR TITLE
Fix undefined `pswp`

### DIFF
--- a/photoswipe-dynamic-caption-plugin.esm.js
+++ b/photoswipe-dynamic-caption-plugin.esm.js
@@ -388,7 +388,7 @@ class PhotoSwipeDynamicCaption {
   }
 
   updateCaptionHTML() {
-    const captionHTML = this.getCaptionHTML(pswp.currSlide);
+    const captionHTML = this.getCaptionHTML(this.pswp.currSlide);
     this.captionElement.style.visibility = captionHTML ? 'visible' :  'hidden';
     this.captionElement.innerHTML = captionHTML || '';
     this.pswp.dispatch('dynamicCaptionUpdateHTML', { 


### PR DESCRIPTION
Fixed a crash caused by undefined `pswp` variable, in the context of `updateCaptionHTML` method.