### PR TITLE
Add export for css file for javascript imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "style": "photoswipe-dynamic-caption-plugin.css",
   "type": "module",
   "exports": {
-    ".": "./photoswipe-dynamic-caption-plugin.esm.js"
+    ".": "./photoswipe-dynamic-caption-plugin.esm.js",
+    "./photoswipe-dynamic-caption-plugin.css": "./photoswipe-dynamic-caption-plugin.css"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
fixes #11 

Allows users who import this CSS file via their JavaScript code (rather than through a `<link>` tag) to continue to do so.